### PR TITLE
Fix double registry prefix in image name

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -1,6 +1,6 @@
 ---
 service: b3s
-image: ghcr.io/b3s/b3s
+image: b3s/b3s
 
 ssh:
   user: app


### PR DESCRIPTION
`config/deploy.yml` set `image: ghcr.io/b3s/b3s` while `registry.server` is already `ghcr.io`, so Kamal prepended the registry twice and images were tagged `ghcr.io/ghcr.io/b3s/b3s`.

Harmless at runtime, but confusing when reading `docker images` output.

Dropping the redundant prefix so the composed name resolves to `ghcr.io/b3s/b3s`.

Note: this orphans the existing `ghcr.io/ghcr.io/b3s/b3s` images on the host, which need pruning after the deploy.